### PR TITLE
Update Pupil Labs LSL Relay Docs

### DIFF
--- a/Apps/PupilLabs/README.md
+++ b/Apps/PupilLabs/README.md
@@ -33,6 +33,7 @@ Primitive data streams consist of 5 channels (`lsl.cf_double64`):
     - `norm_pos.y`
 
 These fields reference the fields described in this data format section: [pupil_positionscsv](https://github.com/pupil-labs/pupil-docs/blob/master/user-docs/data-format.md#pupil_positionscsv)
+
 Where, for example, `diameter` refers to the diameter that is uncorrected for perspective. To find the diameter that is corrected for perspective, use the Python representation to get the field `diameter_3d` (and many other fields not available to the Primitive representation).
 
 Python Representation streams consist of 1 channel containing the

--- a/Apps/PupilLabs/README.md
+++ b/Apps/PupilLabs/README.md
@@ -32,6 +32,9 @@ Primitive data streams consist of 5 channels (`lsl.cf_double64`):
     - `norm_pos.x`
     - `norm_pos.y`
 
+These fields reference the fields described in this data format section: [pupil_positionscsv](https://github.com/pupil-labs/pupil-docs/blob/master/user-docs/data-format.md#pupil_positionscsv)
+Where, for example, `diameter` refers to the diameter that is uncorrected for perspective. To find the diameter that is corrected for perspective, use the Python representation to get the field `diameter_3d` (and many other fields not available to the Primitive representation).
+
 Python Representation streams consist of 1 channel containing the
 Python repr() string of the datum.
 


### PR DESCRIPTION
This patch adds information about how to find different data fields in the data returned from Pupil Labs using the LSL Relay Plugin, and what they refer to in the Pupil Labs data format. It also gives a bit of extra information about the `diameter` field. The following issue has been created for this: https://github.com/pupil-labs/pupil/issues/1281